### PR TITLE
feat: add neo4j_document_id for cross-service document ID consistency

### DIFF
--- a/internal/database/migrations/005_add_neo4j_document_id.sql
+++ b/internal/database/migrations/005_add_neo4j_document_id.sql
@@ -1,0 +1,20 @@
+-- Migration 005: Add neo4j_document_id for cross-service document ID consistency
+-- Created: 2026-01-17
+-- Purpose: Store the Neo4j Document.id from Aether-BE to enable cross-service data integrity
+--          This solves the document ID mismatch issue (GitHub Issue #7) where AudiModal File.id
+--          differs from Neo4j Document.id, making cross-service lookups unreliable.
+
+-- Add neo4j_document_id column to files table
+-- This column stores the UUID from Neo4j Document.id when a file is created via Aether-BE
+ALTER TABLE files ADD COLUMN neo4j_document_id VARCHAR(36);
+
+-- Create index for efficient lookups by neo4j_document_id
+CREATE INDEX idx_files_neo4j_document_id ON files(neo4j_document_id);
+
+-- Create unique index to ensure one-to-one mapping (only where value is not null)
+-- This prevents duplicate mappings while allowing null values for files not created via Aether-BE
+CREATE UNIQUE INDEX idx_files_neo4j_document_id_unique
+    ON files(neo4j_document_id) WHERE neo4j_document_id IS NOT NULL;
+
+-- Add comment for documentation
+COMMENT ON COLUMN files.neo4j_document_id IS 'Neo4j Document.id from Aether-BE for cross-service data integrity. Null for files not created via Aether-BE.';

--- a/internal/database/models/file.go
+++ b/internal/database/models/file.go
@@ -52,6 +52,11 @@ type File struct {
 	DataSourceID        *uuid.UUID `gorm:"type:uuid;index" json:"data_source_id,omitempty"`
 	ProcessingSessionID *uuid.UUID `gorm:"type:uuid;index" json:"processing_session_id,omitempty"`
 
+	// Cross-service document ID from Neo4j (Aether-BE)
+	// This enables cross-service data integrity by storing the Document.id from Neo4j
+	// when files are created via Aether-BE document upload flow
+	Neo4jDocumentID *string `gorm:"type:varchar(36);index" json:"neo4j_document_id,omitempty"`
+
 	// File identification
 	URL         string `gorm:"not null;index" json:"url"`
 	Path        string `gorm:"not null;index" json:"path"`

--- a/internal/processors/tier_processor.go
+++ b/internal/processors/tier_processor.go
@@ -278,6 +278,19 @@ func (tp *TierProcessor) generateEmbeddings(ctx context.Context, request *Proces
 		return 0, fmt.Errorf("failed to get tenant repository: %w", err)
 	}
 
+	// Get the file to check for Neo4j Document ID for cross-service consistency
+	var file models.File
+	if err := tenantRepo.DB().Where("id = ?", request.FileID).First(&file).Error; err != nil {
+		return 0, fmt.Errorf("failed to get file: %w", err)
+	}
+
+	// Use Neo4j Document ID if available, otherwise fall back to AudiModal file ID
+	// This ensures embeddings in DeepLake use the same document ID as Neo4j (Aether-BE)
+	documentID := request.FileID.String()
+	if file.Neo4jDocumentID != nil && *file.Neo4jDocumentID != "" {
+		documentID = *file.Neo4jDocumentID
+	}
+
 	var chunks []models.Chunk
 	if err := tenantRepo.DB().Where("file_id = ?", request.FileID).Find(&chunks).Error; err != nil {
 		return 0, fmt.Errorf("failed to get chunks: %w", err)
@@ -304,17 +317,18 @@ func (tp *TierProcessor) generateEmbeddings(ctx context.Context, request *Proces
 		for j, chunk := range batch {
 			chunkInputs[j] = &embeddings.ChunkInput{
 				ID:          chunk.ChunkID,
-				DocumentID:  chunk.FileID.String(),
+				DocumentID:  documentID, // Use Neo4j Document ID for cross-service consistency
 				Content:     chunk.Content,
 				ChunkIndex:  chunk.ChunkNumber,
 				ContentType: chunk.ChunkType,
 				Metadata: map[string]interface{}{
-					"file_id":       chunk.FileID.String(),
-					"chunk_number":  chunk.ChunkNumber,
-					"size_bytes":    chunk.SizeBytes,
-					"processed_at":  chunk.ProcessedAt,
-					"language":      chunk.Language,
-					"quality_score": chunk.Quality.Completeness,
+					"file_id":           chunk.FileID.String(), // Keep AudiModal file ID in metadata for reference
+					"neo4j_document_id": documentID,            // Explicit Neo4j Document ID for cross-service queries
+					"chunk_number":      chunk.ChunkNumber,
+					"size_bytes":        chunk.SizeBytes,
+					"processed_at":      chunk.ProcessedAt,
+					"language":          chunk.Language,
+					"quality_score":     chunk.Quality.Completeness,
 				},
 			}
 		}

--- a/internal/server/handlers/file.go
+++ b/internal/server/handlers/file.go
@@ -76,6 +76,7 @@ type FileResponse struct {
 	TenantID            uuid.UUID              `json:"tenant_id"`
 	DataSourceID        *uuid.UUID             `json:"data_source_id,omitempty"`
 	ProcessingSessionID *uuid.UUID             `json:"processing_session_id,omitempty"`
+	Neo4jDocumentID     *string                `json:"document_id,omitempty"` // Neo4j Document.id for cross-service consistency
 	URL                 string                 `json:"url"`
 	Path                string                 `json:"path"`
 	Filename            string                 `json:"filename"`
@@ -347,6 +348,12 @@ func (h *FileHandler) handleFileUpload(w http.ResponseWriter, r *http.Request, t
 		}
 	}
 
+	// Get optional document_id for cross-service consistency (Neo4j Document.id from Aether-BE)
+	var neo4jDocumentID *string
+	if documentID := r.FormValue("document_id"); documentID != "" {
+		neo4jDocumentID = &documentID
+	}
+
 	// Extract file information
 	filename := fileHeader.Filename
 	extension := filepath.Ext(filename)
@@ -431,6 +438,7 @@ func (h *FileHandler) handleFileUpload(w http.ResponseWriter, r *http.Request, t
 	fileRecord := &models.File{
 		TenantID:         tenantID,
 		DataSourceID:     &dataSourceID,
+		Neo4jDocumentID:  neo4jDocumentID,
 		URL:              fileURL,
 		Path:             storagePath,
 		Filename:         filename,
@@ -471,6 +479,7 @@ func (h *FileHandler) handleJSONFileCreate(w http.ResponseWriter, r *http.Reques
 		ChecksumType        string                 `json:"checksum_type,omitempty"`
 		DataSourceID        *uuid.UUID             `json:"data_source_id,omitempty"`
 		ProcessingSessionID *uuid.UUID             `json:"processing_session_id,omitempty"`
+		DocumentID          string                 `json:"document_id,omitempty"`  // Neo4j Document.id from Aether-BE for cross-service consistency
 		Metadata            map[string]interface{} `json:"metadata,omitempty"`
 		ValidateAccess      bool                   `json:"validate_access,omitempty"` // Whether to validate S3 access
 	}
@@ -559,10 +568,16 @@ func (h *FileHandler) handleJSONFileCreate(w http.ResponseWriter, r *http.Reques
 		}
 	} else {
 		// Handle local file URLs or manual metadata-only records
+		var neo4jDocID *string
+		if req.DocumentID != "" {
+			neo4jDocID = &req.DocumentID
+		}
+
 		fileRecord = &models.File{
 			TenantID:            tenantID,
 			DataSourceID:        req.DataSourceID,
 			ProcessingSessionID: req.ProcessingSessionID,
+			Neo4jDocumentID:     neo4jDocID,
 			URL:                 req.URL,
 			Path:                req.Path,
 			Filename:            req.Filename,
@@ -849,10 +864,18 @@ func (h *FileHandler) ProcessFile(w http.ResponseWriter, r *http.Request, tenant
 				// Publish processing complete/failed event to Kafka for cross-service sync
 				if h.eventProducer != nil {
 					var eventData events.ProcessingCompleteData
+
+					// Get the Neo4j Document ID for cross-service consistency
+					var documentID string
+					if updatedFile.Neo4jDocumentID != nil {
+						documentID = *updatedFile.Neo4jDocumentID
+					}
+
 					if err == nil && tierResult != nil && tierResult.ProcessingResult != nil {
 						// Success case - now includes actual embedding count
 						eventData = events.ProcessingCompleteData{
 							FileID:              fileID.String(), // AudiModal file UUID for cross-service lookup
+							DocumentID:          documentID,      // Neo4j Document.id for cross-service consistency
 							URL:                 updatedFile.URL,
 							TotalProcessingTime: tierResult.ProcessingTime,
 							ChunksCreated:       tierResult.ChunksCreated,
@@ -870,6 +893,7 @@ func (h *FileHandler) ProcessFile(w http.ResponseWriter, r *http.Request, tenant
 						}
 						eventData = events.ProcessingCompleteData{
 							FileID:              fileID.String(),
+							DocumentID:          documentID, // Neo4j Document.id for cross-service consistency
 							URL:                 updatedFile.URL,
 							TotalProcessingTime: processingTime,
 							ChunksCreated:       0,
@@ -1067,6 +1091,7 @@ func (h *FileHandler) toFileResponse(file *models.File) FileResponse {
 		TenantID:            file.TenantID,
 		DataSourceID:        file.DataSourceID,
 		ProcessingSessionID: file.ProcessingSessionID,
+		Neo4jDocumentID:     file.Neo4jDocumentID,
 		URL:                 file.URL,
 		Path:                file.Path,
 		Filename:            file.Filename,

--- a/pkg/events/types.go
+++ b/pkg/events/types.go
@@ -226,7 +226,8 @@ func (e *ProcessingCompleteEvent) GetBase() BaseEvent {
 }
 
 type ProcessingCompleteData struct {
-	FileID              string        `json:"file_id"` // AudiModal file UUID
+	FileID              string        `json:"file_id"`                        // AudiModal file UUID
+	DocumentID          string        `json:"document_id,omitempty"`          // Neo4j Document.id from Aether-BE for cross-service consistency
 	URL                 string        `json:"url"`
 	TotalProcessingTime time.Duration `json:"total_processing_time"`
 	ChunksCreated       int           `json:"chunks_created"`

--- a/scripts/backfill_neo4j_document_ids.go
+++ b/scripts/backfill_neo4j_document_ids.go
@@ -1,0 +1,189 @@
+// Package main provides a data migration script to backfill neo4j_document_id
+// for existing files in the AudiModal database.
+//
+// This script resolves GitHub Issue #7 by extracting Neo4j Document IDs from
+// MinIO storage paths and updating the corresponding file records.
+//
+// MinIO path pattern: .../documents/{neo4j_document_id}/filename
+//
+// Usage:
+//   go run scripts/backfill_neo4j_document_ids.go --dry-run  # Preview changes
+//   go run scripts/backfill_neo4j_document_ids.go            # Apply changes
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// File represents a minimal file record for migration
+type File struct {
+	ID              uuid.UUID `gorm:"type:uuid;primary_key"`
+	TenantID        uuid.UUID `gorm:"type:uuid;not null"`
+	URL             string    `gorm:"not null"`
+	Path            string    `gorm:"not null"`
+	Neo4jDocumentID *string   `gorm:"type:varchar(36)"`
+	UpdatedAt       time.Time
+}
+
+func (File) TableName() string {
+	return "files"
+}
+
+var (
+	dryRun  = flag.Bool("dry-run", false, "Preview changes without applying them")
+	verbose = flag.Bool("verbose", false, "Enable verbose output")
+	limit   = flag.Int("limit", 0, "Limit number of records to process (0 = no limit)")
+)
+
+// Regex pattern to extract Neo4j Document ID from storage path
+// Pattern: .../documents/{neo4j_document_id}/... or .../documents/{neo4j_document_id}
+var documentIDPattern = regexp.MustCompile(`/documents/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(?:/|$)`)
+
+func main() {
+	flag.Parse()
+
+	fmt.Println("=== Neo4j Document ID Backfill Script ===")
+	fmt.Printf("Mode: %s\n", map[bool]string{true: "DRY RUN (no changes)", false: "LIVE (applying changes)"}[*dryRun])
+	fmt.Println()
+
+	// Get database connection string from environment
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		// Fallback to individual env vars
+		host := os.Getenv("POSTGRES_HOST")
+		if host == "" {
+			host = "localhost"
+		}
+		port := os.Getenv("POSTGRES_PORT")
+		if port == "" {
+			port = "5432"
+		}
+		user := os.Getenv("POSTGRES_USER")
+		if user == "" {
+			user = "tasuser"
+		}
+		password := os.Getenv("POSTGRES_PASSWORD")
+		if password == "" {
+			password = "taspassword"
+		}
+		database := os.Getenv("POSTGRES_DB")
+		if database == "" {
+			database = "tas_shared"
+		}
+		dbURL = fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
+			host, port, user, password, database)
+	}
+
+	// Connect to database
+	db, err := gorm.Open(postgres.Open(dbURL), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		fmt.Printf("ERROR: Failed to connect to database: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	// Get files that need backfilling (neo4j_document_id is NULL)
+	var files []File
+	query := db.WithContext(ctx).Where("neo4j_document_id IS NULL")
+	if *limit > 0 {
+		query = query.Limit(*limit)
+	}
+
+	if err := query.Find(&files).Error; err != nil {
+		fmt.Printf("ERROR: Failed to query files: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Found %d files with NULL neo4j_document_id\n\n", len(files))
+
+	if len(files) == 0 {
+		fmt.Println("No files need backfilling.")
+		return
+	}
+
+	// Process files
+	updatedCount := 0
+	skippedCount := 0
+	errorCount := 0
+
+	for _, file := range files {
+		// Try to extract document ID from URL first, then Path
+		documentID := extractDocumentID(file.URL)
+		if documentID == "" {
+			documentID = extractDocumentID(file.Path)
+		}
+
+		if documentID == "" {
+			if *verbose {
+				fmt.Printf("SKIP: File %s - no document ID found in URL (%s) or Path (%s)\n",
+					file.ID.String(), file.URL, file.Path)
+			}
+			skippedCount++
+			continue
+		}
+
+		// Validate extracted UUID
+		if _, err := uuid.Parse(documentID); err != nil {
+			if *verbose {
+				fmt.Printf("SKIP: File %s - invalid document ID format: %s\n",
+					file.ID.String(), documentID)
+			}
+			skippedCount++
+			continue
+		}
+
+		if *verbose || *dryRun {
+			fmt.Printf("UPDATE: File %s -> neo4j_document_id = %s\n",
+				file.ID.String(), documentID)
+		}
+
+		if !*dryRun {
+			// Apply update
+			if err := db.WithContext(ctx).Model(&file).
+				Update("neo4j_document_id", documentID).Error; err != nil {
+				fmt.Printf("ERROR: Failed to update file %s: %v\n", file.ID.String(), err)
+				errorCount++
+				continue
+			}
+		}
+
+		updatedCount++
+	}
+
+	// Print summary
+	fmt.Println()
+	fmt.Println("=== Summary ===")
+	fmt.Printf("Total files processed: %d\n", len(files))
+	fmt.Printf("Files updated: %d\n", updatedCount)
+	fmt.Printf("Files skipped: %d (no document ID in path)\n", skippedCount)
+	fmt.Printf("Errors: %d\n", errorCount)
+
+	if *dryRun {
+		fmt.Println()
+		fmt.Println("This was a DRY RUN. No changes were made.")
+		fmt.Println("Run without --dry-run to apply changes.")
+	}
+}
+
+// extractDocumentID extracts a Neo4j Document ID from a path string
+// Expected path pattern: .../documents/{uuid}/...
+func extractDocumentID(path string) string {
+	matches := documentIDPattern.FindStringSubmatch(path)
+	if len(matches) >= 2 {
+		return matches[1]
+	}
+	return ""
+}


### PR DESCRIPTION
Resolves GitHub Issue #7 - Document ID mismatch between Neo4j, AudiModal, and DeepLake that prevented cross-service data integrity.

Changes:
- Add neo4j_document_id column to files table (migration 005)
- Accept document_id parameter in file upload API (JSON and multipart)
- Return neo4j_document_id in file responses
- Include DocumentID in processing.complete Kafka events
- Use Neo4j Document ID for DeepLake embeddings when available
- Add backfill script to populate existing files from Neo4j

This enables:
- Cross-service document lookups using consistent IDs
- DeepLake vectors tagged with Neo4j Document IDs
- Backward compatibility (document_id is optional)