### PR TITLE
fix: publish document.processed/failed activity events from all processing paths

### DIFF
--- a/cmd/assembler/main.go
+++ b/cmd/assembler/main.go
@@ -74,6 +74,15 @@ func main() {
 	}
 	defer producer.Close()
 
+	// Activity CloudEvents publisher — feeds the Live Streams panel and
+	// TimescaleDB events table. Distinct from `producer` above, which
+	// publishes legacy ProcessingCompleteEvents on the cross-service topic.
+	activityPublisher := events.NewActivityPublisher(events.ActivityPublisherConfig{
+		BootstrapServers: bootstrapServers,
+		Logger:           log.Default(),
+	})
+	defer func() { _ = activityPublisher.Close() }()
+
 	// Create Kafka consumer for page results
 	reader := kafka.NewReader(kafka.ReaderConfig{
 		Brokers:     []string{bootstrapServers},
@@ -124,7 +133,7 @@ func main() {
 				continue
 			}
 
-			processPageResult(ctx, msg, db, s3Uploader, producer)
+			processPageResult(ctx, msg, db, s3Uploader, producer, activityPublisher)
 
 			if err := reader.CommitMessages(ctx, msg); err != nil {
 				log.Printf("[Assembler] Error committing offset: %v", err)
@@ -133,7 +142,7 @@ func main() {
 	}
 }
 
-func processPageResult(ctx context.Context, msg kafka.Message, db *gorm.DB, s3Uploader *services.S3Uploader, producer *events.SimpleProducer) {
+func processPageResult(ctx context.Context, msg kafka.Message, db *gorm.DB, s3Uploader *services.S3Uploader, producer *events.SimpleProducer, activityPublisher *events.ActivityPublisher) {
 	var result events.PageResultMessage
 	if err := json.Unmarshal(msg.Value, &result); err != nil {
 		log.Printf("[Assembler] Failed to unmarshal page result: %v", err)
@@ -217,11 +226,12 @@ func processPageResult(ctx context.Context, msg kafka.Message, db *gorm.DB, s3Up
 		jobID.String(), job.CompletedPages, job.FailedPages, job.TotalPages)
 
 	// Determine final status based on failure rate
-	assembleFile(ctx, db, s3Uploader, producer, &job, tenantID, fileID)
+	assembleFile(ctx, db, s3Uploader, producer, activityPublisher, &job, tenantID, fileID)
 }
 
 func assembleFile(ctx context.Context, db *gorm.DB, s3Uploader *services.S3Uploader,
-	producer *events.SimpleProducer, job *models.ProcessingJob, tenantID, fileID uuid.UUID) {
+	producer *events.SimpleProducer, activityPublisher *events.ActivityPublisher,
+	job *models.ProcessingJob, tenantID, fileID uuid.UUID) {
 
 	// Update job to assembling
 	db.Model(job).Updates(map[string]any{
@@ -249,6 +259,9 @@ func assembleFile(ctx context.Context, db *gorm.DB, s3Uploader *services.S3Uploa
 				"processed_at":        &now,
 				"processing_duration": processingDuration,
 			})
+
+		// Publish CloudEvent so the Live Streams panel shows the failure.
+		publishActivityFailed(ctx, activityPublisher, tenantID, fileID, job.ID, "assemble", errMsg)
 		return
 	}
 
@@ -457,9 +470,9 @@ func assembleFile(ctx context.Context, db *gorm.DB, s3Uploader *services.S3Uploa
 	updateFileStatus(db, tenantID, fileID, "processed", "")
 	db.Model(&models.File{}).Where("id = ? AND tenant_id = ?", fileID, tenantID).
 		Updates(map[string]any{
-			"chunk_count":          chunkCount,
-			"processed_at":         &now,
-			"processing_duration":  processingDuration,
+			"chunk_count":         chunkCount,
+			"processed_at":        &now,
+			"processing_duration": processingDuration,
 		})
 
 	pipelineMetrics.AssemblerFilesCompleted.Inc()
@@ -469,26 +482,30 @@ func assembleFile(ctx context.Context, db *gorm.DB, s3Uploader *services.S3Uploa
 		fileID.String(), chunkCount, job.FailedPages)
 
 	// Publish processing complete event
-	publishCompleteEvent(ctx, producer, tenantID, fileID, file, chunkCount, job)
+	publishCompleteEvent(ctx, producer, activityPublisher, tenantID, fileID, file, chunkCount, pageResults, job)
 }
 
 func publishCompleteEvent(ctx context.Context, producer *events.SimpleProducer,
-	tenantID, fileID uuid.UUID, file models.File, chunkCount int, job *models.ProcessingJob) {
+	activityPublisher *events.ActivityPublisher,
+	tenantID, fileID uuid.UUID, file models.File, chunkCount int,
+	pageResults []models.PipelinePageResult, job *models.ProcessingJob) {
 
 	var documentID string
 	if file.Neo4jDocumentID != nil {
 		documentID = *file.Neo4jDocumentID
 	}
 
+	success := job.FailedPages == 0
+
 	eventData := events.ProcessingCompleteData{
-		FileID:              fileID.String(),
-		DocumentID:          documentID,
-		URL:                 file.URL,
-		ChunksCreated:       chunkCount,
-		DLPViolationsFound:  0,
-		FinalDataClass:      "internal",
-		StorageLocation:     file.Path,
-		Success:             job.FailedPages == 0,
+		FileID:             fileID.String(),
+		DocumentID:         documentID,
+		URL:                file.URL,
+		ChunksCreated:      chunkCount,
+		DLPViolationsFound: 0,
+		FinalDataClass:     "internal",
+		StorageLocation:    file.Path,
+		Success:            success,
 	}
 
 	event := events.NewProcessingCompleteEvent("audimodal-assembler", tenantID.String(), eventData)
@@ -497,6 +514,63 @@ func publishCompleteEvent(ctx context.Context, producer *events.SimpleProducer,
 	} else {
 		log.Printf("[Assembler] Published processing complete event for file %s", fileID.String())
 	}
+
+	// Activity CloudEvent for the Live Streams panel + TimescaleDB events
+	// table. Separate from the legacy event above, which is consumed by
+	// aether-be's processing_event_handler for cross-service sync.
+	if activityPublisher == nil {
+		return
+	}
+
+	durationMS := time.Since(job.CreatedAt).Milliseconds()
+	if success {
+		activityPublisher.PublishDocumentProcessed(ctx, tenantID.String(), "", job.ID.String(),
+			events.DocumentProcessedPayload{
+				FileID:     fileID.String(),
+				FileName:   file.Filename,
+				ChunkCount: chunkCount,
+				DurationMS: durationMS,
+				Confidence: averageOCRConfidence(pageResults),
+			})
+	} else {
+		errMsg := fmt.Sprintf("%d of %d pages failed", job.FailedPages, job.TotalPages)
+		publishActivityFailed(ctx, activityPublisher, tenantID, fileID, job.ID, "assemble", errMsg)
+	}
+}
+
+// publishActivityFailed fire-and-forget publishes a document.failed CloudEvent.
+// requestID falls back to the job ID so consumers can correlate with the
+// originating processing job.
+func publishActivityFailed(ctx context.Context, activityPublisher *events.ActivityPublisher,
+	tenantID, fileID, jobID uuid.UUID, stage, errMsg string) {
+
+	if activityPublisher == nil {
+		return
+	}
+	activityPublisher.PublishDocumentFailed(ctx, tenantID.String(), "", jobID.String(),
+		events.DocumentFailedPayload{
+			FileID: fileID.String(),
+			Stage:  stage,
+			Error:  errMsg,
+		})
+}
+
+// averageOCRConfidence returns the mean OCR confidence across pages that
+// reported a confidence value. Returns 0 when none did (PDFs with native
+// text layers skip OCR), which omitempty will drop from the JSON payload.
+func averageOCRConfidence(pageResults []models.PipelinePageResult) float64 {
+	var sum float64
+	var n int
+	for _, pr := range pageResults {
+		if pr.OCRConfidence != nil {
+			sum += *pr.OCRConfidence
+			n++
+		}
+	}
+	if n == 0 {
+		return 0
+	}
+	return sum / float64(n)
 }
 
 func publishDLPJobs(ctx context.Context, producer *events.SimpleProducer, chunks []models.Chunk, tenantID, fileID string) {

--- a/internal/server/handlers/file.go
+++ b/internal/server/handlers/file.go
@@ -21,8 +21,8 @@ import (
 	"github.com/jscharber/audimodal/internal/processors"
 	"github.com/jscharber/audimodal/internal/server/response"
 	"github.com/jscharber/audimodal/internal/services"
-	"github.com/jscharber/audimodal/pkg/embeddings"
 	"github.com/jscharber/audimodal/pkg/dlp/types"
+	"github.com/jscharber/audimodal/pkg/embeddings"
 	"github.com/jscharber/audimodal/pkg/events"
 )
 
@@ -524,7 +524,7 @@ func (h *FileHandler) handleJSONFileCreate(w http.ResponseWriter, r *http.Reques
 		ChecksumType        string                 `json:"checksum_type,omitempty"`
 		DataSourceID        *uuid.UUID             `json:"data_source_id,omitempty"`
 		ProcessingSessionID *uuid.UUID             `json:"processing_session_id,omitempty"`
-		DocumentID          string                 `json:"document_id,omitempty"`  // Neo4j Document.id from Aether-BE for cross-service consistency
+		DocumentID          string                 `json:"document_id,omitempty"` // Neo4j Document.id from Aether-BE for cross-service consistency
 		Metadata            map[string]interface{} `json:"metadata,omitempty"`
 		ValidateAccess      bool                   `json:"validate_access,omitempty"` // Whether to validate S3 access
 	}
@@ -822,24 +822,24 @@ func (h *FileHandler) DeleteFile(w http.ResponseWriter, r *http.Request, tenantI
 
 // chunkWithContentResponse is the response struct that includes full content from S3
 type chunkWithContentResponse struct {
-	ID             uuid.UUID              `json:"id"`
-	TenantID       uuid.UUID              `json:"tenant_id"`
-	FileID         uuid.UUID              `json:"file_id"`
-	ChunkID        string                 `json:"chunk_id"`
-	ChunkType      string                 `json:"chunk_type"`
-	ChunkNumber    int                    `json:"chunk_number"`
-	Content        string                 `json:"content"`
-	ContentPreview string                 `json:"content_preview,omitempty"`
-	ContentHash    string                 `json:"content_hash"`
-	SizeBytes      int64                  `json:"size_bytes"`
-	PageNumber     *int                   `json:"page_number,omitempty"`
-	LineNumber     *int                   `json:"line_number,omitempty"`
-	ProcessedAt    string                 `json:"processed_at"`
-	ProcessedBy    string                 `json:"processed_by"`
-	Language       string                 `json:"language,omitempty"`
-	Metadata       models.ChunkMetadata   `json:"metadata,omitempty"`
-	CreatedAt      string                 `json:"created_at"`
-	UpdatedAt      string                 `json:"updated_at"`
+	ID             uuid.UUID            `json:"id"`
+	TenantID       uuid.UUID            `json:"tenant_id"`
+	FileID         uuid.UUID            `json:"file_id"`
+	ChunkID        string               `json:"chunk_id"`
+	ChunkType      string               `json:"chunk_type"`
+	ChunkNumber    int                  `json:"chunk_number"`
+	Content        string               `json:"content"`
+	ContentPreview string               `json:"content_preview,omitempty"`
+	ContentHash    string               `json:"content_hash"`
+	SizeBytes      int64                `json:"size_bytes"`
+	PageNumber     *int                 `json:"page_number,omitempty"`
+	LineNumber     *int                 `json:"line_number,omitempty"`
+	ProcessedAt    string               `json:"processed_at"`
+	ProcessedBy    string               `json:"processed_by"`
+	Language       string               `json:"language,omitempty"`
+	Metadata       models.ChunkMetadata `json:"metadata,omitempty"`
+	CreatedAt      string               `json:"created_at"`
+	UpdatedAt      string               `json:"updated_at"`
 }
 
 // ListFileChunks handles GET /api/v1/tenants/{tenant_id}/files/{id}/chunks
@@ -1068,6 +1068,20 @@ func (h *FileHandler) ProcessFile(w http.ResponseWriter, r *http.Request, tenant
 								fmt.Printf("INFO: Published processing failed event for file %s to Kafka\n", fileID.String())
 							}
 						}
+
+						// Activity CloudEvent for the Live Streams panel + TimescaleDB.
+						// Splitter never got to the assembler, so this is the only
+						// place a document.failed event for this file can originate.
+						if h.activityPublisher != nil {
+							ceTenantID := canonicalTenantID(r, tenantID.String())
+							go h.activityPublisher.PublishDocumentFailed(r.Context(), ceTenantID, "", getRequestID(r),
+								events.DocumentFailedPayload{
+									FileID:   fileID.String(),
+									FileName: updatedFile.Filename,
+									Stage:    "split",
+									Error:    err.Error(),
+								})
+						}
 					}
 				}
 				return
@@ -1201,6 +1215,36 @@ func (h *FileHandler) ProcessFile(w http.ResponseWriter, r *http.Request, tenant
 							map[bool]string{true: "complete", false: "failed"}[eventData.Success], fileID.String(), eventData.EmbeddingsCreated)
 					}
 				}
+
+				// Activity CloudEvent for the Live Streams panel + TimescaleDB
+				// events table. Separate from the legacy event above, which is
+				// consumed by aether-be's processing_event_handler.
+				if h.activityPublisher != nil {
+					ceTenantID := canonicalTenantID(r, tenantID.String())
+					durationMS := time.Since(processingStartTime).Milliseconds()
+					if err == nil && tierResult != nil && tierResult.ProcessingResult != nil {
+						go h.activityPublisher.PublishDocumentProcessed(r.Context(), ceTenantID, "", getRequestID(r),
+							events.DocumentProcessedPayload{
+								FileID:     fileID.String(),
+								FileName:   updatedFile.Filename,
+								ChunkCount: tierResult.ChunksCreated,
+								DurationMS: durationMS,
+								Confidence: tierResult.ProcessingResult.QualityScore,
+							})
+					} else {
+						errMsg := "processing returned no result"
+						if err != nil {
+							errMsg = err.Error()
+						}
+						go h.activityPublisher.PublishDocumentFailed(r.Context(), ceTenantID, "", getRequestID(r),
+							events.DocumentFailedPayload{
+								FileID:   fileID.String(),
+								FileName: updatedFile.Filename,
+								Stage:    "process",
+								Error:    errMsg,
+							})
+					}
+				}
 			} else {
 				fmt.Printf("ERROR: Failed to reload file %s for status update: %v\n", fileID.String(), dbErr)
 			}
@@ -1244,6 +1288,36 @@ func (h *FileHandler) ProcessFile(w http.ResponseWriter, r *http.Request, tenant
 					updatedFile.CalculateProcessingDuration(processingStartTime)
 				}
 				backgroundTenantRepo.DB().Save(&updatedFile)
+
+				// Activity CloudEvent for the Live Streams panel + TimescaleDB.
+				// The basic pipeline doesn't publish a legacy event either, so this
+				// is the only signal downstream consumers get for this path.
+				if h.activityPublisher != nil {
+					ceTenantID := canonicalTenantID(r, tenantID.String())
+					durationMS := time.Since(processingStartTime).Milliseconds()
+					if err == nil && result != nil {
+						go h.activityPublisher.PublishDocumentProcessed(r.Context(), ceTenantID, "", getRequestID(r),
+							events.DocumentProcessedPayload{
+								FileID:     fileID.String(),
+								FileName:   updatedFile.Filename,
+								ChunkCount: result.ChunksCreated,
+								DurationMS: durationMS,
+								Confidence: result.QualityScore,
+							})
+					} else {
+						errMsg := "processing returned no result"
+						if err != nil {
+							errMsg = err.Error()
+						}
+						go h.activityPublisher.PublishDocumentFailed(r.Context(), ceTenantID, "", getRequestID(r),
+							events.DocumentFailedPayload{
+								FileID:   fileID.String(),
+								FileName: updatedFile.Filename,
+								Stage:    "process",
+								Error:    errMsg,
+							})
+					}
+				}
 			}
 		}()
 	} else {

--- a/pkg/events/envelope.go
+++ b/pkg/events/envelope.go
@@ -63,11 +63,15 @@ type DocumentUploadedPayload struct {
 }
 
 // DocumentProcessedPayload is carried by ActivityDocumentProcessed events.
+// Confidence is the pipeline's quality score for the extracted content, in
+// the range [0.0, 1.0] (from ProcessingResult.QualityScore). The Live Streams
+// panel surfaces this as the document's analysis confidence.
 type DocumentProcessedPayload struct {
-	FileID     string `json:"file_id"`
-	FileName   string `json:"file_name,omitempty"`
-	ChunkCount int    `json:"chunk_count,omitempty"`
-	DurationMS int64  `json:"duration_ms,omitempty"`
+	FileID     string  `json:"file_id"`
+	FileName   string  `json:"file_name,omitempty"`
+	ChunkCount int     `json:"chunk_count,omitempty"`
+	DurationMS int64   `json:"duration_ms,omitempty"`
+	Confidence float64 `json:"confidence,omitempty"`
 }
 
 // DocumentFailedPayload is carried by ActivityDocumentFailed events.


### PR DESCRIPTION
## Summary

Fills the gap that caused stats and analysis confidence to not appear in the Live Streams panel after document uploads. The CloudEvents publisher introduced in #23 was only wired for `document.uploaded`; downstream `document.processed` / `document.failed` events were never emitted, so the events-aggregator never wrote them to TimescaleDB and the Live Streams stats stayed at zero.

Wires `ActivityPublisher.PublishDocumentProcessed` / `PublishDocumentFailed` at every processing exit point.

## Stacking

Based on `feature/gatekeeper-streaming` (#23), not `main`, because it depends on `ActivityPublisher`. Merge after (or fold into) #23.

## Changes

### Commit `0fc0720` — assembler

- `cmd/assembler/main.go`: initialize `ActivityPublisher` next to the existing `SimpleProducer`; plumb through `processPageResult` → `assembleFile` → `publishCompleteEvent`. Publishes `document.processed` on success (with chunk count, duration, and average per-page OCR confidence) and `document.failed` on too-many-failed-pages or partial-fail.
- `pkg/events/envelope.go`: adds optional `Confidence float64` (`omitempty`) to `DocumentProcessedPayload`. Backward-compatible.

### Commit `c6b24fd` — file handler

Adds the same dual-publish to the three exit paths in `internal/server/handlers/file.go` that the assembler change doesn't cover:

- **Splitter submit-failure** (`h.splitter.SplitFile` returns an error before any pages reach the assembler) → `document.failed`, `Stage="split"`
- **embeddingCoordinator** (non-PDF / non-S3 / Splitter unavailable) → `document.processed` with `TierProcessingResult.QualityScore` as confidence, or `document.failed` with `Stage="process"`
- **Basic-pipeline fallback** (`h.pipeline` only, no embeddings) — previously emitted no events at all; activity publish is the only downstream signal here

Each call mirrors the existing `PublishDocumentUploaded` pattern: fire-and-forget goroutine, `canonicalTenantID(r, ...)` to forward the aether tenant ID via `X-Aether-Tenant-Id`, `getRequestID(r)` for the request ID. Gated on `h.activityPublisher != nil`.

## Coverage matrix

After this PR, all four processing exit points produce activity CloudEvents:

| Exit point | Success event | Failure event |
|---|---|---|
| Splitter → Assembler (PDFs, S3) | `document.processed` | `document.failed`, Stage=`assemble` |
| Splitter submit (queue failure) | n/a | `document.failed`, Stage=`split` |
| embeddingCoordinator (non-PDF / non-S3) | `document.processed` (Confidence=`QualityScore`) | `document.failed`, Stage=`process` |
| Basic pipeline (no embeddings) | `document.processed` | `document.failed`, Stage=`process` |

## Verification

| Check | Result |
|---|---|
| `gofmt -l` on touched files | clean |
| `go build ./cmd/assembler` | clean |
| `go build ./pkg/events/...` | clean |
| `go build ./internal/server/handlers/...` | clean |
| `go test ./pkg/events/...` | `ok` |

Pre-existing issues outside the scope of this PR:
- `scripts/`: `main redeclared in this block` (two files declaring `main` in the same package)
- `internal/server/handlers/file_handler_test.go`: `unreachable code` warnings after `t.Skip()` calls

## Test plan

- [ ] Deploy to dev cluster (audimodal-assembler and audimodal-be both need rebuild — both packages changed).
- [ ] Upload a PDF.
- [ ] Watch Loki: `{namespace="aether-be"} |~ "document.processed"` — confirm the event fires from the assembler within ~30s of upload.
- [ ] After ~1–2 min, query TimescaleDB:
  ```sql
  SELECT type, count(*) FROM events
  WHERE tenant_id='<your-tenant>' AND time >= NOW() - INTERVAL '10 min'
  GROUP BY type;
  ```
  Expect both `com.tas.activity.document.uploaded` AND `com.tas.activity.document.processed`.
- [ ] Live Streams panel stats reflect the bump.
- [ ] Inspect a processed-event payload — `confidence` field present and in [0.0, 1.0] for PDFs that triggered OCR; absent for native-text PDFs (correct `omitempty` behavior).
- [ ] Upload a non-PDF file (e.g. a `.txt`) — confirm `document.processed` also fires for the embeddingCoordinator path.
- [ ] Force a failure (e.g. corrupt PDF) — confirm `document.failed` event with appropriate `stage` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)