### PR TITLE
fix: pin Gatekeeper as versioned module (unbreak shared image build)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -68,9 +68,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     
-    - name: Checkout Gatekeeper (public sibling for the ../Gatekeeper replace)
-      run: git clone --depth 1 https://github.com/Tributary-ai-services/Gatekeeper.git "$GITHUB_WORKSPACE/../Gatekeeper"
-
     - name: Download dependencies
       run: go mod download
     
@@ -337,9 +334,6 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
         check-latest: true
     
-    - name: Checkout Gatekeeper (public sibling for the ../Gatekeeper replace)
-      run: git clone --depth 1 https://github.com/Tributary-ai-services/Gatekeeper.git "$GITHUB_WORKSPACE/../Gatekeeper"
-
     - name: Download dependencies
       run: go mod download
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,9 +56,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-${{ matrix.go-version }}-
           
-    - name: Checkout Gatekeeper (public sibling for the ../Gatekeeper replace)
-      run: git clone --depth 1 https://github.com/Tributary-ai-services/Gatekeeper.git "$GITHUB_WORKSPACE/../Gatekeeper"
-
     - name: Download dependencies
       run: go mod download
       
@@ -151,9 +148,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-1.21-
           
-    - name: Checkout Gatekeeper (public sibling for the ../Gatekeeper replace)
-      run: git clone --depth 1 https://github.com/Tributary-ai-services/Gatekeeper.git "$GITHUB_WORKSPACE/../Gatekeeper"
-
     - name: Download dependencies
       run: go mod download
       
@@ -196,9 +190,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-1.21-
           
-    - name: Checkout Gatekeeper (public sibling for the ../Gatekeeper replace)
-      run: git clone --depth 1 https://github.com/Tributary-ai-services/Gatekeeper.git "$GITHUB_WORKSPACE/../Gatekeeper"
-
     - name: Download dependencies
       run: go mod download
       

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,11 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o ocrworker ./cmd/o
 # Build assembler binary for Kafka pipeline
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o assembler ./cmd/assembler
 
-# Build DLP worker binary for Kafka pipeline
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o dlpworker ./cmd/dlpworker
+# Build DLP worker binary for Kafka pipeline.
+# -tags nohs: dlpworker links Gatekeeper's scanner (pkg/dlp/shadow) whose default
+# engine is cgo Hyperscan; nohs selects its cgo-free Go regexp engine so this
+# stays CGO_ENABLED=0 with no libhyperscan/pkg-config in the image.
+RUN CGO_ENABLED=0 GOOS=linux go build -tags nohs -a -installsuffix cgo -o dlpworker ./cmd/dlpworker
 
 # Build embedding worker binary for Kafka pipeline
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o embeddingworker ./cmd/embeddingworker

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
-
 	// Core dependencies
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.10.9
@@ -31,7 +30,7 @@ require (
 
 require (
 	cloud.google.com/go/storage v1.56.0
-	github.com/Tributary-ai-services/Gatekeeper v0.0.0-00010101000000-000000000000
+	github.com/Tributary-ai-services/Gatekeeper v0.0.0-20260717185958-05032a9e9780
 	github.com/aws/aws-sdk-go-v2 v1.37.1
 	github.com/aws/aws-sdk-go-v2/config v1.30.2
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.2
@@ -160,8 +159,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-// Gatekeeper is developed in-tree alongside audimodal; resolve it to the local
-// sibling path. Used by pkg/dlp/shadow to dual-run Gatekeeper's scanner against
-// audimodal's DLP (audimodal#26, G6).
-replace github.com/Tributary-ai-services/Gatekeeper => ../Gatekeeper

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.53.0/go.mod h1:jUZ5LYlw40WMd07qxcQJD5M40aUxrfwqQX1g7zxYnrQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0 h1:Ron4zCA/yk6U7WOBXhTJcDpsUBG9npumK6xw2auFltQ=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0/go.mod h1:cSgYe11MCNYunTnRXrKiR/tHc0eoKjICUuWpNZoVCOo=
+github.com/Tributary-ai-services/Gatekeeper v0.0.0-20260717185958-05032a9e9780 h1:H+VlXn0hehlfeTTT0SlTtLg1e0cl+MbdBIUeOB/efyA=
+github.com/Tributary-ai-services/Gatekeeper v0.0.0-20260717185958-05032a9e9780/go.mod h1:rLvSlQJfF89K7s4j1pB8ldwE2CHG74zLrVoepCQgtXI=
 github.com/aws/aws-sdk-go-v2 v1.37.1 h1:SMUxeNz3Z6nqGsXv0JuJXc8w5YMtrQMuIBmDx//bBDY=
 github.com/aws/aws-sdk-go-v2 v1.37.1/go.mod h1:9Q0OoGQoboYIAJyslFyF1f5K1Ryddop8gqMhWx/n4Wg=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.0 h1:6GMWV6CNpA/6fbFHnoAjrv4+LGfyTqZz2LtCHnspgDg=


### PR DESCRIPTION
G6 added `replace => ../Gatekeeper`, a sibling-path dependency that can't resolve in the Docker builder (context is the audimodal dir only). That broke the shared `audimodal:latest` image build used by all six workers, and forced a Gatekeeper sibling-clone hack in CI.

Gatekeeper is public, so this pins it as a normal versioned require (`v0.0.0-20260717185958-05032a9e9780`, current Gatekeeper `main`). `go mod download` now fetches from the proxy — builds anywhere with no sibling.

- `go.mod`/`go.sum`: drop the replace, add the versioned require
- `Dockerfile`: `-tags nohs` on the dlpworker build (it links Gatekeeper's scanner, whose default engine is cgo Hyperscan; nohs keeps `CGO_ENABLED=0`)
- CI: drop the now-unneeded Gatekeeper sibling-clone steps (`GOFLAGS=-tags=nohs` and the golangci `build-tags` stay — the shadow still links the cgo engine)

Validated with a full local image build (32/32 steps) producing a functional `dlpworker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)