### PR TITLE
chore(dlp-worker): enable Gatekeeper shadow (G6) in the manifest

### DIFF
--- a/deployments/kubernetes/dlp-worker-deployment.yaml
+++ b/deployments/kubernetes/dlp-worker-deployment.yaml
@@ -26,13 +26,18 @@ spec:
     spec:
       containers:
       - name: dlp-worker
-        image: registry-api.tas.scharber.com/audimodal:latest
+        image: registry-api.tas.scharber.com/audimodal:g6-93f5615
         command: ["./dlpworker"]
         ports:
         - name: health
           containerPort: 8081
           protocol: TCP
         env:
+        # G6: dual-run Gatekeeper alongside audimodal's DLP and log the per-type
+        # finding diff (audimodal authoritative, result unchanged). Measure-only —
+        # docs/AIQG-GATEKEEPER-INTEGRATION.md §4a, audimodal#26.
+        - name: DLP_SHADOW_SCAN
+          value: "true"
         - name: KAFKA_BOOTSTRAP_SERVERS
           value: "kafka-shared.tas-shared.svc.cluster.local:9092"
         - name: KAFKA_GROUP_ID


### PR DESCRIPTION
Syncs the `aether-be/audimodal-dlp-worker` manifest with the live cluster after turning on the G6 shadow:

- `DLP_SHADOW_SCAN=true` — dual-run Gatekeeper alongside audimodal's DLP and log the per-type finding diff (measure-only; audimodal stays authoritative, result unchanged)
- image pinned to `audimodal:g6-93f5615`, built from the versioned-Gatekeeper main (#29)

Verified live: the new pod logs `[DLPWorker] Gatekeeper shadow scanning ENABLED` and runs 1/1 with 0 restarts. Diff lines (`dlp-shadow:`) will appear in Loki as documents flow through DLP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)